### PR TITLE
Refactoring events

### DIFF
--- a/web-ui/app/js/dispatchers/left_pane_dispatcher.js
+++ b/web-ui/app/js/dispatchers/left_pane_dispatcher.js
@@ -47,19 +47,14 @@ define(
           this.trigger(document, events.router.pushState, data);
         }
         initialized = true;
-
-        if (data.skipMailListRefresh) {
-          return;
-        }
-
-        this.trigger(document, events.ui.mails.fetchByTag, data);
       };
 
       this.after('initialize', function () {
-        this.on(this.$node, events.tags.received, this.loadTags);
+        //this.on(this.$node, events.tags.received, this.loadTags);
         this.on(document, events.dispatchers.tags.refreshTagList, this.refreshTagList);
         this.on(document, events.ui.tags.loaded, this.selectTag);
         this.on(document, events.ui.tag.selected, this.pushUrlState);
+        this.on(document, events.ui.tag.select, this.pushUrlState);
         this.trigger(document, events.tags.want, { caller: this.$node });
       });
     }

--- a/web-ui/app/js/dispatchers/right_pane_dispatcher.js
+++ b/web-ui/app/js/dispatchers/right_pane_dispatcher.js
@@ -101,6 +101,7 @@ define(
         this.on(document, events.dispatchers.rightPane.openNoMessageSelected, this.openNoMessageSelectedPane);
         this.on(document, events.dispatchers.rightPane.selectTag, this.selectTag);
         this.on(document, events.ui.tag.selected, this.saveTag);
+        this.on(document, events.ui.tag.select, this.saveTag);
         this.on(document, events.dispatchers.rightPane.openNoMessageSelectedWithoutPushState, this.initializeNoMessageSelectedPane);
         this.initializeNoMessageSelectedPane();
       });

--- a/web-ui/app/js/helpers/monitored_ajax.js
+++ b/web-ui/app/js/helpers/monitored_ajax.js
@@ -56,7 +56,6 @@ define(['page/events', 'views/i18n'], function (events, i18n) {
         on.trigger(document, events.ui.userAlerts.displayMessage, { message: i18n(msg) });
       }
     }.bind(this));
-
   }
 
   return monitoredAjax;

--- a/web-ui/app/js/mail_list/ui/mail_items/mail_item.js
+++ b/web-ui/app/js/mail_list/ui/mail_items/mail_item.js
@@ -32,6 +32,7 @@ define(
 
     this.doSelect = function () {
       this.$node.addClass('selected');
+      this.checkCheckbox();
     };
 
     this.doUnselect = function () {
@@ -72,6 +73,7 @@ define(
     this.attachListeners = function () {
       this.on(this.$node.find('input[type=checkbox]'), 'change', this.triggerMailChecked);
       this.on(document, events.ui.mails.cleanSelected, this.doUnselect);
+      this.on(document, events.ui.tag.select, this.doUnselect);
       this.on(document, events.ui.mails.uncheckAll, this.uncheckCheckbox);
       this.on(document, events.ui.mails.checkAll, this.checkCheckbox);
     };

--- a/web-ui/app/js/mail_list/ui/mail_list.js
+++ b/web-ui/app/js/mail_list/ui/mail_list.js
@@ -125,7 +125,7 @@ define(
       };
 
       this.updateCheckAllCheckbox = function () {
-        this.trigger(document, events.ui.mails.hasMailsChecked, {hasMailsChecked: this.attr.checkedMails.length > 0});
+        this.trigger(document, events.ui.mails.hasMailsChecked, {hasMailsChecked: _.keys(this.attr.checkedMails).length > 0});
       };
 
       this.addToSelectedMails = function (ev, data) {

--- a/web-ui/app/js/mail_list/ui/mail_list.js
+++ b/web-ui/app/js/mail_list/ui/mail_list.js
@@ -121,23 +121,11 @@ define(
       };
 
       this.respondWithCheckedMails = function (ev, caller) {
-        this.trigger(caller, events.ui.mail.hereChecked, { checkedMails: this.checkedMailsForCurrentTag()});
+        this.trigger(caller, events.ui.mail.hereChecked, {checkedMails: self.attr.checkedMails});
       };
 
       this.updateCheckAllCheckbox = function () {
-        if (this.checkedMailsForCurrentTag().length > 0) {
-          this.trigger(document, events.ui.mails.hasMailsChecked, true);
-        } else {
-          this.trigger(document, events.ui.mails.hasMailsChecked, false);
-        }
-      };
-
-      this.checkedMailsForCurrentTag = function () {
-        var checkedMailsForCurrentTag = _.filter(self.attr.checkedMails, function (mail) {
-          return  self.attr.currentTag === 'all' || mail.mailbox === self.attr.currentTag || _.contains(mail.tags, self.attr.currentTag);
-        });
-
-        return checkedMailsForCurrentTag.length > 0 ? checkedMailsForCurrentTag : {};
+        this.trigger(document, events.ui.mails.hasMailsChecked, {hasMailsChecked: this.attr.checkedMails.length > 0});
       };
 
       this.addToSelectedMails = function (ev, data) {
@@ -177,6 +165,7 @@ define(
         self = this;
 
         this.on(document, events.ui.mails.cleanSelected, this.cleanSelected);
+        this.on(document, events.ui.tag.select, this.cleanSelected);
 
         this.on(document, events.mails.available, this.showMails);
         this.on(document, events.mails.availableForRefresh, this.refreshMailList);

--- a/web-ui/app/js/mixins/with_auto_refresh.js
+++ b/web-ui/app/js/mixins/with_auto_refresh.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2014 ThoughtWorks, Inc.
+ *
+ * Pixelated is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Pixelated is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Pixelated. If not, see <http://www.gnu.org/licenses/>.
+ */
+/*global Pixelated */
+/*global _ */
+
+define(['features'],
+  function (features) {
+    'use strict';
+
+    function withAutoRefresh(refreshMethod) {
+      return function () {
+        this.defaultAttrs({
+          refreshInterval: 15000
+        });
+
+        this.setupRefresher = function () {
+          clearTimeout(this.attr.refreshTimer);
+          this.attr.refreshTimer = setTimeout(function () {
+            this[refreshMethod]();
+            this.setupRefresher();
+          }.bind(this), this.attr.refreshInterval);
+        };
+
+        this.after('initialize', function () {
+          if (features.isAutoRefreshEnabled()) {
+            this.setupRefresher();
+          }
+        });
+      };
+    }
+
+    return withAutoRefresh;
+  }
+);
+

--- a/web-ui/app/js/mixins/with_mail_edit_base.js
+++ b/web-ui/app/js/mixins/with_mail_edit_base.js
@@ -212,6 +212,7 @@ define(
         this.on(document, events.ui.mail.send, this.sendMail);
 
         this.on(document, events.ui.tag.selected, this.saveTag);
+        this.on(document, events.ui.tag.select, this.saveTag);
       });
     }
 

--- a/web-ui/app/js/page/router.js
+++ b/web-ui/app/js/page/router.js
@@ -34,6 +34,7 @@ define(['flight/lib/component', 'page/events', 'page/router/url_params'], functi
       return {
         tag: data.tag || (previousState && previousState.tag) || urlParams.defaultTag(),
         mailIdent: data.mailIdent,
+        query: data.query,
         isDisplayNoMessageSelected: !!data.isDisplayNoMessageSelected
       };
     }
@@ -61,6 +62,9 @@ define(['flight/lib/component', 'page/events', 'page/router/url_params'], functi
 
     this.after('initialize', function () {
       this.on(document, events.router.pushState, this.pushState);
+      this.on(document, events.ui.tag.select, this.pushState);
+      this.on(document, events.search.perform, this.pushState);
+      this.on(document, events.search.empty, this.pushState);
       window.onpopstate = this.popState.bind(this);
     });
   });

--- a/web-ui/app/js/search/search_trigger.js
+++ b/web-ui/app/js/search/search_trigger.js
@@ -46,16 +46,14 @@ define(
         var value = input.val();
         input.blur();
         if(!_.isEmpty(value)){
-          this.trigger(document, events.ui.tag.select, { tag: 'all', skipMailListRefresh: true });
           this.trigger(document, events.search.perform, { query: value });
         } else {
-          this.trigger(document, events.ui.tag.select, { tag: 'all'});
           this.trigger(document, events.search.empty);
         }
       };
 
-      this.clearInput = function(event, data) {
-        if (!data.skipMailListRefresh) { this.select('input').val(''); }
+      this.clearInput = function() {
+        this.select('input').val('');
       };
 
       this.showOnlySearchTerms = function(event){
@@ -77,6 +75,7 @@ define(
         this.on(this.select('input'), 'focus', this.showOnlySearchTerms);
         this.on(this.select('input'), 'blur', this.showSearchTermsAndPlaceHolder);
         this.on(document, events.ui.tag.selected, this.clearInput);
+        this.on(document, events.ui.tag.select, this.clearInput);
       });
     }
   }

--- a/web-ui/app/js/tags/data/tags.js
+++ b/web-ui/app/js/tags/data/tags.js
@@ -14,12 +14,12 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with Pixelated. If not, see <http://www.gnu.org/licenses/>.
  */
-define(['flight/lib/component', 'page/events', 'helpers/monitored_ajax', 'mixins/with_feature_toggle'], function (defineComponent, events, monitoredAjax,  withFeatureToggle) {
+define(['flight/lib/component', 'page/events', 'helpers/monitored_ajax', 'mixins/with_feature_toggle', 'mixins/with_auto_refresh'], function (defineComponent, events, monitoredAjax,  withFeatureToggle, withAutoRefresh) {
   'use strict';
 
   var DataTags = defineComponent(dataTags, withFeatureToggle('tags', function() {
     $(document).trigger(events.ui.mails.refresh);
-  }));
+  }), withAutoRefresh('refreshTags'));
 
   DataTags.all = {
     name: 'all',
@@ -34,13 +34,11 @@ define(['flight/lib/component', 'page/events', 'helpers/monitored_ajax', 'mixins
     }
   };
 
-  return DataTags;
-
   function dataTags() {
     function sendTagsBackTo(on, params) {
       return function(data) {
         data.push(DataTags.all);
-        on.trigger(params.caller, events.tags.received, {tags: data, skipMailListRefresh: params.skipMailListRefresh});
+        on.trigger(params.caller, events.tags.received, {tags: data});
       };
     }
 
@@ -53,8 +51,14 @@ define(['flight/lib/component', 'page/events', 'helpers/monitored_ajax', 'mixins
         .done(sendTagsBackTo(this, params));
     };
 
+    this.refreshTags = function() {
+      this.fetchTags(null, {caller: document});
+    };
+
     this.after('initialize', function () {
       this.on(document, events.tags.want, this.fetchTags);
     });
   }
+
+  return DataTags;
 });

--- a/web-ui/app/js/tags/ui/tag.js
+++ b/web-ui/app/js/tags/ui/tag.js
@@ -39,15 +39,16 @@ define(
     return Tag;
 
     function tag() {
-    
-      this.viewFor = function (tag, template) {
+
+      this.viewFor = function (tag, template, currentTag) {
         return template({
           tagName: tag.default ? i18n('tags.' + tag.name) : tag.name,
           ident: this.hashIdent(tag.ident),
           count: this.badgeType(tag) === 'total' ? tag.counts.total : (tag.counts.total - tag.counts.read),
           displayBadge: this.displayBadge(tag),
           badgeType: this.badgeType(tag),
-          icon: tag.icon
+          icon: tag.icon,
+          selected: tag.name === currentTag ? 'selected' : ''
         });
       };
 
@@ -55,7 +56,7 @@ define(
         var mailbox_and_tags = _.flatten([data.tags, data.mailbox]);
         if (_.contains(mailbox_and_tags, this.attr.tag.name)) {
           this.attr.tag.counts.read++;
-          this.$node.html(this.viewFor(this.attr.tag, templates.tags.tagInner));
+          this.$node.html(this.viewFor(this.attr.tag, templates.tags.tagInner, this.attr.currentTag));
           if (!_.isUndefined(this.attr.shortcut)) {
             this.attr.shortcut.reRender();
           }
@@ -64,23 +65,6 @@ define(
 
       this.triggerSelect = function () {
         this.trigger(document, events.ui.tag.select, { tag: this.attr.tag.name });
-        this.trigger(document, events.search.empty);
-      };
-
-      this.selectTag = function (ev, data) {
-        if(data.tag === this.attr.tag.name) { this.doSelect(data); }
-        else { this.doUnselect(); }
-      };
-
-      this.doUnselect = function () {
-        this.attr.selected = false;
-        this.$node.removeClass('selected');
-      };
-
-      this.doSelect = function (data) {
-        this.attr.selected = true;
-        this.$node.addClass('selected');
-        this.trigger(document, events.ui.tag.selected, data);
       };
 
       this.addSearchingClass = function() {
@@ -112,14 +96,13 @@ define(
 
       this.after('initialize', function () {
         this.on('click', this.triggerSelect);
-        this.on(document, events.ui.tag.select, this.selectTag);
         this.on(document, events.mail.read, this.decreaseReadCountIfMatchingTag);
         this.on(document, events.search.perform, this.addSearchingClass);
         this.on(document, events.search.empty, this.removeSearchingClass);
       });
 
       this.renderAndAttach = function (parent, data) {
-        var rendered = this.viewFor(data.tag, templates.tags.tag);
+        var rendered = this.viewFor(data.tag, templates.tags.tag, data.currentTag);
         parent.append(rendered);
         this.initialize('#tag-' + this.hashIdent(data.tag.ident), data);
         this.on(parent, events.tags.teardown, this.teardown);

--- a/web-ui/app/js/tags/ui/tag.js
+++ b/web-ui/app/js/tags/ui/tag.js
@@ -65,6 +65,8 @@ define(
 
       this.triggerSelect = function () {
         this.trigger(document, events.ui.tag.select, { tag: this.attr.tag.name });
+
+        this.removeSearchingClass();
       };
 
       this.addSearchingClass = function() {

--- a/web-ui/app/js/tags/ui/tag_base.js
+++ b/web-ui/app/js/tags/ui/tag_base.js
@@ -34,6 +34,33 @@ define(['views/i18n', 'page/events'], function(i18n, events) {
       return _.include(TOTAL_BADGE, tag.name) ? 'total' : 'unread';
     };
 
+    this.doUnselect = function () {
+      this.$node.removeClass('selected');
+    };
+
+    this.doSelect = function () {
+      this.$node.addClass('selected');
+    };
+
+    this.selectTag = function (ev, data) {
+      this.attr.currentTag = data.tag;
+      if (data.tag === this.attr.tag.name) {
+        this.doSelect();
+      }
+      else {
+        this.doUnselect();
+      }
+    };
+
+    this.selectTagAll = function () {
+      this.selectTag(null, {tag: 'all'});
+    };
+
+    this.after('initialize', function () {
+      this.on(document, events.ui.tag.select, this.selectTag);
+      this.on(document, events.search.perform, this.selectTagAll);
+      this.on(document, events.search.empty, this.selectTagAll);
+    });
   }
 
   return tagBase;

--- a/web-ui/app/js/tags/ui/tag_shortcut.js
+++ b/web-ui/app/js/tags/ui/tag_shortcut.js
@@ -38,24 +38,25 @@ define(
 
     function tagShortcut() {
 
-      this.renderTemplate = function (linkTo) {
+      this.renderTemplate = function (tag, currentTag) {
         var model = {
-          tagName: linkTo.name,
-          displayBadge: this.displayBadge(linkTo),
-          badgeType: this.badgeType(linkTo),
-          count: this.badgeType(linkTo) === 'total' ? linkTo.counts.total : (linkTo.counts.total - linkTo.counts.read),
-          icon: iconFor[linkTo.name]
+          tagName: tag.name,
+          displayBadge: this.displayBadge(tag),
+          badgeType: this.badgeType(tag),
+          count: this.badgeType(tag) === 'total' ? tag.counts.total : (tag.counts.total - tag.counts.read),
+          icon: iconFor[tag.name],
+          selected: tag.name === currentTag ? 'selected' : ''
         };
         return templates.tags.shortcut(model);
       };
 
       this.renderAndAttach = function (parent, options) {
-        parent.append(this.renderTemplate(options.linkTo));
+        parent.append(this.renderTemplate(options.tag, options.currentTag));
         this.initialize(parent.children().last(), options);
       };
 
       this.reRender = function () {
-        this.$node.html(this.renderTemplate(this.attr.linkTo));
+        this.$node.html(this.renderTemplate(this.attr.tag, this.attr.currentTag));
       };
 
       var iconFor = {
@@ -64,23 +65,6 @@ define(
         'drafts': 'pencil',
         'trash': 'trash-o',
         'all': 'archive'
-      };
-
-      this.selectTag = function (ev, data) {
-        if (data.tag === this.attr.linkTo.name) {
-          this.doSelect();
-        }
-        else {
-          this.doUnselect();
-        }
-      };
-
-      this.doUnselect = function () {
-        this.$node.removeClass('selected');
-      };
-
-      this.doSelect = function () {
-        this.$node.addClass('selected');
       };
 
       this.doTeardown = function () {
@@ -93,7 +77,6 @@ define(
         this.on('click', function () {
           this.attr.trigger.triggerSelect();
         });
-        this.on(document, events.ui.tag.select, this.selectTag);
         this.on(document, events.tags.shortcuts.teardown, this.doTeardown);
       });
 

--- a/web-ui/app/templates/tags/shortcut.hbs
+++ b/web-ui/app/templates/tags/shortcut.hbs
@@ -1,4 +1,4 @@
-<li>
+<li class="{{ selected }}">
   <a title="{{ tagName }}">
     {{#if displayBadge }}
         <span class="{{ badgeType }}-count">{{ count }}</span>

--- a/web-ui/app/templates/tags/tag.hbs
+++ b/web-ui/app/templates/tags/tag.hbs
@@ -1,3 +1,3 @@
-<li id="tag-{{ ident }}">
+<li id="tag-{{ ident }}" class="{{ selected }}">
   {{> tag_inner }}
 </li>

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -20,6 +20,7 @@
   },
   "scripts": {
     "test": "npm run clean && npm run handlebars && node_modules/karma/bin/karma start --single-run --browsers PhantomJS $GRUNT_OPTS",
+    "debug": "npm run clean && npm run handlebars && node_modules/karma/bin/karma start --browsers Chrome $GRUNT_OPTS",
     "watch-test": "node_modules/karma/bin/karma start",
     "handlebars": "mkdir -p app/js/generated/hbs/ && handlebars app/templates/**/*.hbs > app/js/generated/hbs/templates.js --namespace=window.Pixelated --root .",
     "compass": "compass compile",

--- a/web-ui/test/features.js
+++ b/web-ui/test/features.js
@@ -9,6 +9,9 @@ define([], function() {
     },
     getLogoutUrl: function() {
       return '/test/logout/url';
+    },
+    isAutoRefreshEnabled: function() {
+      return true;
     }
   };
 });

--- a/web-ui/test/spec/dispatchers/left_pane_dispatcher.spec.js
+++ b/web-ui/test/spec/dispatchers/left_pane_dispatcher.spec.js
@@ -28,14 +28,6 @@ describeComponent('dispatchers/left_pane_dispatcher', function () {
       expect(pushStateEvent).toHaveBeenTriggeredOn(document, { tag: 'inbox'});
     });
 
-    it('fetches mails by tag when a tag is selected', function () {
-      var fetchByTagEvent = spyOnEvent(document, Pixelated.events.ui.mails.fetchByTag);
-
-      $(document).trigger(Pixelated.events.ui.tag.selected, { tag: 'Drafts'});
-
-      expect(fetchByTagEvent).toHaveBeenTriggeredOn(document, { tag: 'Drafts'});
-    });
-
     it('doesnt fetch mails by tag when skipMailListRefresh is sent on tag.selected', function () {
       var fetchByTagEvent = spyOnEvent(document, Pixelated.events.ui.mails.fetchByTag);
 
@@ -50,30 +42,6 @@ describeComponent('dispatchers/left_pane_dispatcher', function () {
       $(document).trigger(Pixelated.events.dispatchers.tags.refreshTagList, {});
 
       expect(tagWantEvent).toHaveBeenTriggeredOn(document);
-    });
-
-    it('fires tagLoad when the tags are received', function () {
-      var tagListLoadEvent = spyOnEvent(document, Pixelated.events.ui.tagList.load);
-
-      this.$node.trigger(Pixelated.events.tags.received, { tags: ['tags']});
-
-      expect(tagListLoadEvent).toHaveBeenTriggeredOn(document, { tags: ['tags']});
-    });
-
-    it('on tags loaded selects the inbox tag if no data is provided', function () {
-      var selectTagEvent = spyOnEvent(document, Pixelated.events.ui.tag.select);
-
-      $(document).trigger(Pixelated.events.ui.tags.loaded, {});
-
-      expect(selectTagEvent).toHaveBeenTriggeredOnAndWith(document, { tag: 'inbox' });
-    });
-
-    it('on tags loaded selects the a different tag if tag is provided', function () {
-      var selectTagEvent = spyOnEvent(document, Pixelated.events.ui.tag.select);
-
-      $(document).trigger(Pixelated.events.ui.tags.loaded, { tag: 'Drafts' });
-
-      expect(selectTagEvent).toHaveBeenTriggeredOnAndWith(document, { tag: 'Drafts' });
     });
   });
 });

--- a/web-ui/test/spec/mail_list/ui/mail_list.spec.js
+++ b/web-ui/test/spec/mail_list/ui/mail_list.spec.js
@@ -104,22 +104,13 @@ describeComponent('mail_list/ui/mail_list', function () {
       expect(this.component.attr.checkedMails).toEqual({'2': {}, '3': {} });
     });
 
-    it ('does not check the all checkbox if no mail checked has the current tag', function () {
-      var setCheckAllCheckboxEvent = spyOnEvent(document, Pixelated.events.ui.mails.hasMailsChecked);
-      this.component.attr.currentTag = 'inbox';
-
-      $(document).trigger(Pixelated.events.ui.mail.checked, {mail : {'1' : {tags: ['different']}}});
-
-      expect(setCheckAllCheckboxEvent).toHaveBeenTriggeredOnAndWith(document, false);
-    });
-
     it('checks the check all checkbox if at least one mail is checked with the current tag', function () {
       var setCheckAllCheckboxEvent = spyOnEvent(document, Pixelated.events.ui.mails.hasMailsChecked);
       this.component.attr.currentTag = 'inbox';
 
       $(document).trigger(Pixelated.events.ui.mail.checked, {mail: mailList[0]});
 
-      expect(setCheckAllCheckboxEvent).toHaveBeenTriggeredOnAndWith(document, true);
+      expect(setCheckAllCheckboxEvent).toHaveBeenTriggeredOnAndWith(document, {hasMailsChecked: true});
     });
 
     it('unchecks the check all checkbox if no mail is left checked', function () {
@@ -129,7 +120,7 @@ describeComponent('mail_list/ui/mail_list', function () {
 
       $(document).trigger(Pixelated.events.ui.mail.unchecked, {mail: {ident: '1'}});
 
-      expect(setCheckAllCheckboxEvent).toHaveBeenTriggeredOnAndWith(document, false);
+      expect(setCheckAllCheckboxEvent).toHaveBeenTriggeredOnAndWith(document, {hasMailsChecked: false});
     });
   });
 

--- a/web-ui/test/spec/mail_list/ui/mail_list.spec.js
+++ b/web-ui/test/spec/mail_list/ui/mail_list.spec.js
@@ -83,17 +83,6 @@ describeComponent('mail_list/ui/mail_list', function () {
       expect(mailHereCheckedEvent).toHaveBeenTriggeredOnAndWith(caller, { checkedMails: mailList });
     });
 
-    it('returns every checked mail when the curent tag is "all"', function () {
-      var caller = {};
-      this.component.attr.checkedMails = mailList;
-      this.component.attr.currentTag = 'all';
-      var mailHereCheckedEvent = spyOnEvent(caller, Pixelated.events.ui.mail.hereChecked);
-
-      $(document).trigger(Pixelated.events.ui.mail.wantChecked, caller);
-
-      expect(mailHereCheckedEvent).toHaveBeenTriggeredOnAndWith(caller, { checkedMails: mailList });
-    });
-
     it('returns an empty list to whomever requests the checked mails if there are no checked mails with the current tag', function () {
       var caller = {};
       var mailHereCheckedEvent = spyOnEvent(caller, Pixelated.events.ui.mail.hereChecked);

--- a/web-ui/test/spec/search/search_trigger.spec.js
+++ b/web-ui/test/spec/search/search_trigger.spec.js
@@ -22,28 +22,6 @@ describeComponent('search/search_trigger', function () {
     expect(spy).toHaveBeenTriggeredOnAndWith(document, { query: 'tanana' });
   });
 
-  it('should select the "all" tag when submit occurs but should skip mail list refresh', function  (){
-    var tagSelectEvent = spyOnEvent(document, Pixelated.events.ui.tag.select);
-
-    submitSearch('tanana');
-
-    expect(tagSelectEvent).toHaveBeenTriggeredOnAndWith(document, {
-      tag: 'all',
-      skipMailListRefresh: true
-    });
-  });
-
-  it('should select the "all" tag when an empty submit occurs and shoud refresh mail list', function() {
-    var tagSelectEvent = spyOnEvent(document, Pixelated.events.ui.tag.select);
-    var emptySearchEvent = spyOnEvent(document, Pixelated.events.search.empty);
-
-    submitSearch('');
-
-    expect(emptySearchEvent).toHaveBeenTriggeredOn(document);
-    expect(tagSelectEvent).toHaveBeenTriggeredOnAndWith(document, { tag: 'all'});
-
-  });
-
   it('should clear input when selecting a new tag', function(){
     submitSearch('tanana');
     $(document).trigger(Pixelated.events.ui.tag.selected, { tag: 'inbox'});

--- a/web-ui/test/spec/tags/ui/tag.spec.js
+++ b/web-ui/test/spec/tags/ui/tag.spec.js
@@ -23,7 +23,6 @@ describeComponent('tags/ui/tag', function () {
 
       this.component.$node.click();
 
-      expect(this.component.attr.selected).toBeTruthy();
       expect(this.$node.attr('class')).toMatch('selected');
       expect(tagSelectEvent).toHaveBeenTriggeredOnAndWith(document, { tag: 'inbox' });
     });
@@ -94,6 +93,18 @@ describeComponent('tags/ui/tag', function () {
       $(document).trigger(Pixelated.events.mail.read, { tags: ['inbox']});
       expect(this.$node.html()).not.toMatch('"unread-count"');
     });
+
+    it('should not be selected when a search is performed', function() {
+      this.component.trigger(document, Pixelated.events.search.perform);
+
+      expect(this.component.$node).not.toHaveClass('selected');
+    });
+
+    it('should not be selected when the search is cleared', function() {
+      this.component.trigger(document, Pixelated.events.search.empty);
+
+      expect(this.component.$node).not.toHaveClass('selected');
+    });
   });
 
   describe('drafts tag', function () {
@@ -149,6 +160,17 @@ describeComponent('tags/ui/tag', function () {
       expect(this.$node.attr('class')).not.toMatch('searching');
     });
 
+    it('should be selected when a search is performed', function() {
+      this.component.trigger(document, Pixelated.events.search.perform);
+
+      expect(this.component.$node).toHaveClass('selected');
+    });
+
+    it('should be selected when the search is cleared', function() {
+      this.component.trigger(document, Pixelated.events.search.empty);
+
+      expect(this.component.$node).toHaveClass('selected');
+    });
   });
 
   _.each(['sent', 'trash'], function (tag_name) {

--- a/web-ui/test/spec/tags/ui/tag_list.spec.js
+++ b/web-ui/test/spec/tags/ui/tag_list.spec.js
@@ -27,7 +27,7 @@ describeComponent('tags/ui/tag_list', function () {
       this.component.attr.default = false;
       var tagList = [tag('tag1', 1), tag('tag2', 2), tag('tag3', 3)];
 
-      $(document).trigger(Pixelated.events.ui.tagList.load, {tags: tagList});
+      $(document).trigger(Pixelated.events.tags.received, {tags: tagList});
 
       var items = _.map(this.$node.find('li'), function (el) {
         return $(el).attr('id');
@@ -39,7 +39,7 @@ describeComponent('tags/ui/tag_list', function () {
     it('should render the default tags when tagsList:load is received and default attribute is true', function () {
       var tagList = [tag('tag1', 1, false), tag('tag2', 2, true), tag('tag3', 3, true)];
 
-      $(document).trigger(Pixelated.events.ui.tagList.load, {tags: tagList});
+      $(document).trigger(Pixelated.events.tags.received, {tags: tagList});
 
       var items = _.map(this.component.select('defaultTagList').find('li'), function (el) {
         return $(el).attr('id');
@@ -51,7 +51,7 @@ describeComponent('tags/ui/tag_list', function () {
     it('should render the custom tags when tagsList:load is received and default attribute is false', function () {
       var tagList = [tag('tag1', 1, false), tag('tag2', 2, true), tag('tag3', 3, true)];
 
-      $(document).trigger(Pixelated.events.ui.tagList.load, {tags: tagList});
+      $(document).trigger(Pixelated.events.tags.received, {tags: tagList});
 
       var items = _.map(this.component.select('customTagList').find('li'), function (el) {
         return $(el).attr('id');
@@ -60,35 +60,18 @@ describeComponent('tags/ui/tag_list', function () {
       expect(items).toEqual(['tag-1']);
     });
 
-    it('should trigger event to tell that tags were loaded sending the current tag', function () {
-      this.component.attr.currentTag = 'Drafts';
-      var tagsLoadedEvent = spyOnEvent(document, Pixelated.events.ui.tags.loaded);
-
-      $(document).trigger(Pixelated.events.ui.tagList.load, {tags: [] });
-
-      expect(tagsLoadedEvent).toHaveBeenTriggeredOnAndWith(document, { tag: 'Drafts'});
-    });
-
-    it('should send tag as undefined when tags are loaded and no tag was selected yet', function () {
-      var tagsLoadedEvent = spyOnEvent(document, Pixelated.events.ui.tags.loaded);
-
-      $(document).trigger(Pixelated.events.ui.tagList.load, {tags: [] });
-
-      expect(tagsLoadedEvent).toHaveBeenTriggeredOnAndWith(document, jasmine.objectContaining({ tag: undefined }));
-    });
-
     it('should save the current tag when a tag is selected', function () {
-      $(document).trigger(Pixelated.events.ui.tag.selected, { tag: 'amazing'});
+      $(document).trigger(Pixelated.events.ui.tag.select, { tag: 'amazing'});
 
       expect(this.component.attr.currentTag).toEqual('amazing');
     });
 
     it('resets the tag lists when loading tags', function () {
       var tagList = [tag('tag1', 1, false), tag('tag2', 2, true), tag('tag3', 3, true)];
-      $(document).trigger(Pixelated.events.ui.tagList.load, {tags: tagList});
+      $(document).trigger(Pixelated.events.tags.received, {tags: tagList});
 
       tagList = [tag('tag1', 1, false), tag('tag2', 2, true)];
-      $(document).trigger(Pixelated.events.ui.tagList.load, {tags: tagList});
+      $(document).trigger(Pixelated.events.tags.received, {tags: tagList});
 
       var customTags = _.map(this.component.select('customTagList').find('li'), function (el) {
         return $(el).attr('id');
@@ -103,10 +86,10 @@ describeComponent('tags/ui/tag_list', function () {
 
     it('resets the tag shortcuts when loading tags', function () {
       var tagList = [tag('inbox', 1, true)];
-      $(document).trigger(Pixelated.events.ui.tagList.load, {tags: tagList});
+      $(document).trigger(Pixelated.events.tags.received, {tags: tagList});
 
       tagList = [tag('sent', 1, true)];
-      $(document).trigger(Pixelated.events.ui.tagList.load, {tags: tagList});
+      $(document).trigger(Pixelated.events.tags.received, {tags: tagList});
 
       var shortcuts = _.map($('#tags-shortcuts').find('li'), function (el) {
         return $(el).text().trim();
@@ -120,7 +103,7 @@ describeComponent('tags/ui/tag_list', function () {
       var tagsTeardownDefault = spyOnEvent(this.component.select('defaultTagList'), Pixelated.events.tags.teardown);
       var tagsShortcutsTeardown = spyOnEvent(document, Pixelated.events.tags.shortcuts.teardown);
 
-      $(document).trigger(Pixelated.events.ui.tagList.load, {tags: []});
+      $(document).trigger(Pixelated.events.tags.received, {tags: []});
 
       expect(tagsTeardownCustom).toHaveBeenTriggeredOn(this.component.select('customTagList'));
       expect(tagsTeardownDefault).toHaveBeenTriggeredOn(this.component.select('defaultTagList'));

--- a/web-ui/test/spec/tags/ui/tag_shortcut.spec.js
+++ b/web-ui/test/spec/tags/ui/tag_shortcut.spec.js
@@ -12,7 +12,7 @@ describeComponent('tags/ui/tag_shortcut', function () {
     component = jasmine.createSpyObj('tagComponent', ['triggerSelect']);
     parent = $('<ul>');
     $('body').append(parent);
-    shortcut = TagShortcut.appendedTo(parent, { linkTo: { name: 'inbox', counts: { total: 15 }}, trigger: component });
+    shortcut = TagShortcut.appendedTo(parent, { tag: { name: 'inbox', counts: { total: 15 }}, trigger: component });
   });
 
   afterEach(function () {
@@ -43,7 +43,7 @@ describeComponent('tags/ui/tag_shortcut', function () {
 
   it('teardown shortcuts on event but only if they are not in the DOM', function () {
     parent.empty();
-    var shortcutAddedAfterEmptyingParent = TagShortcut.appendedTo(parent, { linkTo: { name: 'inbox', counts: { total: 15 }}, trigger: component });
+    var shortcutAddedAfterEmptyingParent = TagShortcut.appendedTo(parent, { tag: { name: 'inbox', counts: { total: 15 }}, trigger: component });
     // by now shorcut is not in the DOM anymore but shortcutAddedAfterEmptyingParent is
 
     spyOn(shortcut, 'teardown').and.callThrough();


### PR DESCRIPTION
Moving to a place where events are not used as a component issuing a command to another, but a component issuing an event indicating something happened ("I finished processing something", "something is ready", "the user clicked something"), and all components that care about that particular event would listen for it.

This will increase the number of events that a component will listen to (increase the number of entry points to a component) but it'll also reduce the number of steps (event after event after event) that happen when an interaction (user, receive data from service, etc) happens.

What was changed so far was that the mail list will update the list of emails when the mail service issues the event of new emails, and the mail service listen to ui events that would cause a change of the listed emails (a tag is selected, a search is performed) or a data event (the auto-refresher gets the current list of emails).

The `left_pane_dispatcher.js` will become unnecessary with this, and now I'm working on removing it.