### PR TITLE
#284 - Adds vbguest plugin configuration in order to avoid automatic updates.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,6 +4,17 @@
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
+new_plugin_installed = false
+unless Vagrant.has_plugin?('vagrant-vbguest')
+  plugin = 'vagrant-vbguest'
+  puts "Missing plugin #{plugin}, installing..."
+
+  `vagrant plugin install #{plugin}`
+
+  new_plugin_installed = true
+end
+exec "vagrant #{ARGV.join' '}" if new_plugin_installed
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # All Vagrant configuration is done here. The most common configuration
   # options are documented and commented below. For a complete reference,
@@ -19,10 +30,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # for details
 
   config.vm.box = "leap-jessie-amd64"
-
-  unless Vagrant.has_plugin?("vagrant-vbguest")
-    raise 'plugin vagrant-vbguest is not installed! Please run `vagrant plugin install vagrant-vbguest`'
-  end
 
   config.vbguest.auto_update = false
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,6 +20,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.box = "leap-jessie-amd64"
 
+  unless Vagrant.has_plugin?("vagrant-vbguest")
+    raise 'plugin vagrant-vbguest is not installed! Please run `vagrant plugin install vagrant-vbguest`'
+  end
+
+  config.vbguest.auto_update = false
+
   config.vm.define "source", primary: true do |source|
     source.vm.provider :virtualbox do |v, override|
       override.vm.box_url = "https://downloads.leap.se/platform/vagrant/virtualbox/leap-debian-jessie-amd64-virtualbox.box"


### PR DESCRIPTION
I had difficult to up my vagrant machine with an error and a warning. The error was `"mount: could not find any free loop device"` and the warning was `"Virtual Box Guest Additions with different versions"`. 

When I installed vagrant-vbguest plugin and applied a config on the `Vagrantfile` worked.